### PR TITLE
fix build script by explicitly setting c[pp]_std

### DIFF
--- a/desmume_sys/build.rs
+++ b/desmume_sys/build.rs
@@ -137,6 +137,9 @@ fn main() {
         cmd.arg("build")
             .arg("--default-library=static")
             .arg("-Dbuildtype=release")
+            // Prevent implicit-function-declaration and int-conversion errors
+            .arg("-Dc_std=gnu11")
+            .arg("-Dcpp_std=gnu++14")
             .current_dir(build_dir.join("src/frontend/interface"));
         run(&mut cmd, "meson");
 


### PR DESCRIPTION
[nixpkgs](https://github.com/NixOS/nixpkgs/) maintainer here.

On our side, the `desmume-sys` build script is failing with:

```
  ../../../libretro-common/file/file_path.c:53:24: error: implicit declaration of function ‘strdup’; did you mean ‘strcmp’? [-Wimplicit-function-declaration]
     53 |    char     *basedir = strdup(dir);
        |                        ^~~~~~
        |                        strcmp
  ../../../libretro-common/file/file_path.c:53:24: error: initialization of ‘char *’ from ‘int’ makes pointer from integer without a cast [-Wint-conversion]
```

Explicitly setting `-Dc_std=gnu11` and `-Dcpp_std=gnu++14` fixes the issue.
